### PR TITLE
Add basic support for Publons widget and badges

### DIFF
--- a/symplectic-bootstrapped-vivo/js/publonsAuthorWidget.js
+++ b/symplectic-bootstrapped-vivo/js/publonsAuthorWidget.js
@@ -1,0 +1,37 @@
+$(document).ready(function() {
+    /* Publons author widget
+     *
+     * Insert the Publons author widget if a publons widget div can be found
+     * and it contains what looks to be a Publons id.
+     *
+     * To enable this in a VIVO instance it is necessary to define a data
+     * property with the following attributes:
+     *
+     *   * Public label: Publons widget
+     *   * Property group: [whichever group you want the widget to appear in]
+     *   * Internal name: publonsWidget
+     *   * Domain class: Person (foaf)
+     *   * Range datatype: string
+     *
+     * A Person will then need to populate the property with their Publons url
+     * or id. For example, Andrew Preston would create a Publons Widget property
+     * which contains one of:
+     *   * https://publons.com/a/1/; or
+     *   * 1
+     *
+     * Code (obviously) requires jQuery.
+     */
+    var panel = $("#publonsWidget").closest(".panel");
+    var body = panel.find(".panel-body");
+    var id = body.find(".property-list .list-group-item").text();
+    var id_number = /\d+/.exec(id);
+
+    if ( id_number ) {
+        body.empty();
+        body.html(
+            '<iframe src="https://publons.com/author/' +
+            id_number +
+            '/widget/embed/?width=640&height=460" width="100%" height="460" style="border: 0;"></iframe>'
+        );
+    }
+});

--- a/symplectic-bootstrapped-vivo/js/showcase.js
+++ b/symplectic-bootstrapped-vivo/js/showcase.js
@@ -1,10 +1,11 @@
 
+
 links = $('.individual-urls').find('a');
 for (k = 0; k < links.length; k++)
 {
- 
+
   if (links[k].href.includes("figshare"))
-     {//console.log(links[k].href);     
+     {//console.log(links[k].href);
       var figsharecontent;
       var figshareyql = "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%3D%27"+ encodeURI(links[k].href)+"%27%20and%20xpath%3D%27%2F%2Fscript%5B%40id%20%3D%20%22app-data%22%5D%27&format=json";
       $.getJSON(figshareyql,
@@ -12,7 +13,7 @@ for (k = 0; k < links.length; k++)
                                 //console.log(figsharecontent);
 
                                 figItems = JSON.parse(figsharecontent).items.items;
-                                for (i = 0; i < figItems.length; i++) { 
+                                for (i = 0; i < figItems.length; i++) {
                                      // console.log(figItems[i].data.id);
                                      $.getJSON("https://api.figshare.com/v2/articles/"+figItems[i].data.id,
                                       function(res) {
@@ -36,7 +37,7 @@ for (k = 0; k < links.length; k++)
                                       }, "jsonp");
                                  }
                   }, "jsonp" );
-      
+
 
     }
    if (links[k].href.includes("theconversation"))
@@ -68,8 +69,8 @@ for (k = 0; k < links.length; k++)
        var yql = "https://query.yahooapis.com/v1/public/yql?q=select%20title%2C%20%20content%2C%20link%20from%20atom%20where%20url%3D%22" +
                  encodeURI(links[k].href + '/articles.atom')+
                  "%22&format=json&callback=";
-       $.getJSON(yql, function(res) {      var entries = []; 
-                                           if (typeof res.query.results.entry.length == "undefined" ) {entries = [res.query.results.entry]; console.log(entries);} 
+       $.getJSON(yql, function(res) {      var entries = [];
+                                           if (typeof res.query.results.entry.length == "undefined" ) {entries = [res.query.results.entry]; console.log(entries);}
                                                 else entries = res.query.results.entry;
                                            console.log("entries[0]"); console.log(entries[0]);
                                            for (i = 0; i < entries.length; i++) { console.log(i);
@@ -95,9 +96,9 @@ for (k = 0; k < links.length; k++)
                                                            }
                                                   _altmetric_embed_init();
                       }, "jsonp");
-        
-       
-       
+
+
+
    }
- 
+
 }

--- a/symplectic-bootstrapped-vivo/templates/individual--foaf-academic-article.ftl
+++ b/symplectic-bootstrapped-vivo/templates/individual--foaf-academic-article.ftl
@@ -10,12 +10,13 @@
 
 <#assign individualProductExtensionPreHeader>
     <#include "individual-altmetric.ftl">
+    <#include "individual-publons.ftl">
 </#assign>
 
 <#assign individualProductExtension>
     <#-- Include for any class specific template additions -->
     ${classSpecificExtension!}
-    ${departmentalGrantsExtension!} 
+    ${departmentalGrantsExtension!}
     <!--PREINDIVIDUAL OVERVIEW.FTL-->
     <#include "individual-vocabularyService.ftl">
     <#include "individual-webpage.ftl">
@@ -27,9 +28,9 @@
 </#assign>
 
 <#if individual.conceptSubclass() >
-    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#broader")!> 
-    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#narrower")!> 
-    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#related")!> 
+    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#broader")!>
+    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#narrower")!>
+    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#related")!>
 </#if>
 
 <#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
@@ -96,13 +97,13 @@
     <#else>
             </section> <!-- individual-info -->
         </section> <!-- individual-intro -->
-    </#if> 
+    </#if>
          <div id="readcube" class="embed-responsive embed-responsive-4by3">
             <iframe src="http://www.readcube.com/articles/10.1038/ni.3298" class="embed-responsive-item"></iframe>
          </div>
        </div>
 
-    
+
        <div class="col-sm-3">
           <#if individualProductExtensionPreHeader??>
             ${individualProductExtensionPreHeader}

--- a/symplectic-bootstrapped-vivo/templates/individual--foaf-property-group-tabs.ftl
+++ b/symplectic-bootstrapped-vivo/templates/individual--foaf-property-group-tabs.ftl
@@ -51,7 +51,7 @@
 				<#assign groupNameHtmlId = p.createPropertyGroupHtmlId(groupName) >
 				<#assign verbose = (verbosePropertySwitch.currentValue)!false>
 				<div id="${groupNameHtmlId?replace("/","-")}" class="tab-pane fade in <#if (sectionCount > 1) ><#else>active</#if>" role="tabpanel">
-				<#-- Display the group heading --> 
+				<#-- Display the group heading -->
 					<#if groupName?has_content>
 						<#--the function replaces spaces in the name with underscores, also called for the property group menu-->
 						<#assign groupNameHtmlId = p.createPropertyGroupHtmlId(groupName) >
@@ -91,5 +91,6 @@ ${stylesheets.add('<link rel="stylesheet" href="${urls.base}/css/individual/indi
 ${headScripts.add('<script type="text/javascript" src="${urls.base}/js/amplify/amplify.store.min.js"></script>')}
 ${scripts.add('<script type="text/javascript" src="${urls.base}/js/individual/propertyGroupControls.js"></script>')}
 ${scripts.add('<script type="text/javascript" src="${urls.theme}/js/showcase.js""></script>')}
+${scripts.add('<script type="text/javascript" src="${urls.theme}/js/publonsAuthorWidget.js""></script>')}
 ${scripts.add('<script type="text/javascript" src="${urls.theme}/js/resultsNav.js""></script>')}
 ${scripts.add('<script type="text/javascript" src="${urls.theme}/js/readshare.js""></script>')}

--- a/symplectic-bootstrapped-vivo/templates/individual-publons.ftl
+++ b/symplectic-bootstrapped-vivo/templates/individual-publons.ftl
@@ -1,0 +1,11 @@
+<!-- Publons article badge -->
+
+<#assign doi = propertyGroups.getProperty("http://purl.org/ontology/bibo/doi")!>
+<#if doi?has_content> <#-- true when the property is in the list, even if not populated (when editing) -->
+    <#if doi.statements[0]??>
+        <div class="publons-badge" data-type="square" data-doi="${doi.statements[0].value}" style="float: right; width: 60px; height: 60px;"></div>
+        <script src="https://publons.com/static/badges-v1.js" async></script>
+    </#if>
+</#if>
+
+<! -- /Publons article badge -->

--- a/symplectic-bootstrapped-vivo/templates/individual-publons.ftl
+++ b/symplectic-bootstrapped-vivo/templates/individual-publons.ftl
@@ -8,4 +8,4 @@
     </#if>
 </#if>
 
-<! -- /Publons article badge -->
+<!-- /Publons article badge -->

--- a/symplectic-bootstrapped-vivo/templates/individual.ftl
+++ b/symplectic-bootstrapped-vivo/templates/individual.ftl
@@ -7,12 +7,13 @@
 
 <#assign individualProductExtensionPreHeader>
     <#include "individual-altmetric.ftl">
+    <#include "individual-publons.ftl">
 </#assign>
 
 <#assign individualProductExtension>
     <#-- Include for any class specific template additions -->
     ${classSpecificExtension!}
-    ${departmentalGrantsExtension!} 
+    ${departmentalGrantsExtension!}
     <!--PREINDIVIDUAL OVERVIEW.FTL-->
     <#include "individual-vocabularyService.ftl">
     <#include "individual-webpage.ftl">
@@ -24,9 +25,9 @@
 </#assign>
 
 <#if individual.conceptSubclass() >
-    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#broader")!> 
-    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#narrower")!> 
-    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#related")!> 
+    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#broader")!>
+    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#narrower")!>
+    <#assign overview = propertyGroups.pullProperty("http://www.w3.org/2004/02/skos/core#related")!>
 </#if>
 
 <#include "individual-vitro.ftl">


### PR DESCRIPTION
This pull request extends the bootstrapped VIVO theme to include support for both the Publons:
  * Author widget
  * Publication badge

We have deployed both the widget and badge in production in "beta" status. Details of how they interact with bootstrapped VIVO below.

**Is there in interest in merging this into the bootstrapped theme? Very open to feedback!**

### Author widget

The widget uses jQuery to insert itself into a Person's detail page once the document is loaded:
![image](https://cloud.githubusercontent.com/assets/1124536/20457512/08ca9558-ae85-11e6-8eab-c5bccd5f59cc.png)

  * It requires a "publons widget" data property to be added to the local ontology, but we could also look at pulling the requisite Publons id from the websites section _or_ query based on ORCID
  * Ignore the "editorial activity" and "peer review activity". That's the result of a separate experiment with creating an ontology to capture these activities.

### Publication badge

The badge is embedded in a very similar manner to the existing Altmetric badge:
![screen shot 2016-11-19 at 4 18 09 pm](https://cloud.githubusercontent.com/assets/1124536/20457516/33a27368-ae85-11e6-9a2f-dac93f042ae4.png)